### PR TITLE
Fix README so that install instructions are copy-and-pastable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 ### Installation
 
 ```sh
-$ git clone [git-repo-url]
-$ cd Hot-O-Meter
-$ npm install && bower install
-$ gulp
+git clone https://github.com/alextrastero/Hot-O-Meter.git
+cd Hot-O-Meter
+npm install && bower install
+gulp
 ```
 
 ##### Open browser and go to localhost:3000


### PR DESCRIPTION
El fixo really importante! You cannot have those '$' lingering in your shell instructions...
